### PR TITLE
LRI -> LMF

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@
 The institutions involved are:
 - [CNRS](http://www.cnrs.fr/)
 - [IRIF@Université Paris-Diderot](http://www.irif.fr/)
-- [LRI@Université Paris-Sud](http://www.lri.fr/)
+- [LMF@Université Paris Saclay](https://lmf.cnrs.fr/)
 - [CONICET](http://www.conicet.gov.ar/web/conicet/inicio)
 - [ICC@Universidad de Buenos Aires](https://icc.fcen.uba.ar/)
 - [FAMAF@Universidad de Córdoba](https://www.famaf.unc.edu.ar)


### PR DESCRIPTION
Benoît Valiron speaking here: this is an update of the laboratory name. LRI does not exist anymore, we changed to LMF (Laboratoires Méthodes Formelles)